### PR TITLE
Alias Command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -217,6 +217,18 @@ The `redo` command fails as there are no `undo` commands executed previously.
 Clears all entries from the address book. +
 Format: `clear`
 
+=== Adding aliases : `alias`
+
+Adds an alias to another command. +
+Format: `alias ALIAS COMMAND`
+
+Examples:
+
+* `alias show list` +
+`show` (performs the `list` command) +
+* `alias remove delete` +
+`remove 1` (performs the `delete 1` command) +
+
 === Exiting the program : `exit`
 
 Exits the program. +

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -28,6 +28,7 @@ public class LogicManager extends ComponentManager implements Logic {
         this.model = model;
         this.history = new CommandHistory();
         this.addressBookParser = new AddressBookParser();
+        this.addressBookParser.setAliases(model.getAliases());
         this.undoRedoStack = new UndoRedoStack();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -64,4 +64,8 @@ public class AddCommand extends UndoableCommand {
                 || (other instanceof AddCommand // instanceof handles nulls
                 && toAdd.equals(((AddCommand) other).toAdd));
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+/**
+ * Creates an alias for other commands.
+ */
+public class AliasCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "alias";
+    public static final String MESSAGE_SUCCESS = "The alias \"%1$s\" now points to \"%2$s\".";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates an alias for other commands."
+            + "Parameters: NEW_COMMAND OLD_COMMAND\n"
+            + "Example: " + COMMAND_WORD + " create add";
+
+    private final String alias;
+    private String command;
+
+    public AliasCommand(String alias, String command) {
+        this.alias = alias;
+        this.command = command;
+    }
+
+    @Override
+    public CommandResult executeUndoableCommand() {
+        model.addAlias(alias, command);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, alias, command));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AliasCommand // instanceof handles nulls
+                && this.alias.equals(((AliasCommand) other).alias) // state check
+                && this.command.equals(((AliasCommand) other).command)); // state check
+    }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,11 +12,14 @@ public class ClearCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
-
     @Override
     public CommandResult executeUndoableCommand() {
         requireNonNull(model);
         model.resetData(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -15,6 +15,11 @@ public abstract class Command {
     protected UndoRedoStack undoRedoStack;
 
     /**
+     * Returns the keyword used to call the command
+     */
+    public abstract String getCommandWord();
+
+    /**
      * Constructs a feedback message to summarise an operation that displayed a listing of persons.
      *
      * @param displaySize used to generate summary

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -55,4 +55,8 @@ public class DeleteCommand extends UndoableCommand {
                 || (other instanceof DeleteCommand // instanceof handles nulls
                 && this.targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -212,4 +212,8 @@ public class EditCommand extends UndoableCommand {
                     && getTags().equals(e.getTags());
         }
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -18,4 +18,7 @@ public class ExitCommand extends Command {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
     }
 
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -33,4 +33,8 @@ public class FindCommand extends Command {
                 || (other instanceof FindCommand // instanceof handles nulls
                 && this.predicate.equals(((FindCommand) other).predicate)); // state check
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -20,4 +20,8 @@ public class HelpCommand extends Command {
         EventsCenter.getInstance().post(new ShowHelpRequestEvent());
         return new CommandResult(SHOWING_HELP_MESSAGE);
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HistoryCommand.java
@@ -35,4 +35,8 @@ public class HistoryCommand extends Command {
         requireNonNull(history);
         this.history = history;
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -17,4 +17,8 @@ public class ListCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -33,4 +33,8 @@ public class RedoCommand extends Command {
         this.model = model;
         this.undoRedoStack = undoRedoStack;
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -49,4 +49,8 @@ public class SelectCommand extends Command {
                 || (other instanceof SelectCommand // instanceof handles nulls
                 && this.targetIndex.equals(((SelectCommand) other).targetIndex)); // state check
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -33,4 +33,8 @@ public class UndoCommand extends Command {
         this.model = model;
         this.undoRedoStack = undoRedoStack;
     }
+
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,22 +3,11 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.HistoryCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
-import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -30,6 +19,12 @@ public class AddressBookParser {
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    private Map<String, String> aliases;
+
+    public void setAliases(Map<String, String> aliases) {
+        this.aliases = aliases;
+    }
 
     /**
      * Parses user input into command for execution.
@@ -44,12 +39,20 @@ public class AddressBookParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
+        String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
+
+        if (aliases != null && aliases.get(commandWord) != null) {
+            commandWord = aliases.get(commandWord);
+        }
+
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
+            case AliasCommand.COMMAND_WORD:
+                return new AliasCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AliasCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AliasCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.Optional;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class AliasCommandParser implements Parser<AliasCommand> {
+
+    private String command;
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AliasCommand
+     * and returns an AliasCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AliasCommand parse(String arguments) throws ParseException {
+        String[] args = arguments.trim().split("\\s+");
+
+        if (args.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AliasCommand.MESSAGE_USAGE));
+        }
+
+        String alias = args[0];
+        try {
+            ParserUtil.parseCommand(Optional.ofNullable(args[1])).ifPresent(cmd -> this.command = cmd);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(ive.getMessage(), ive);
+        }
+
+        return new AliasCommand(alias, command);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.*;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -89,5 +90,34 @@ public class ParserUtil {
             tagSet.add(new Tag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses {@code Optional<String> command} and returns itself if it is a valid command, if {@code command} is present.
+     * See header comment of this class regarding the use of {@code Optional} parameters.
+     */
+    public static Optional<String> parseCommand(Optional<String> command) throws IllegalValueException {
+        requireNonNull(command);
+        if (command.isPresent()) {
+            switch (command.get()) {
+                case AddCommand.COMMAND_WORD:
+                case AliasCommand.COMMAND_WORD:
+                case EditCommand.COMMAND_WORD:
+                case SelectCommand.COMMAND_WORD:
+                case DeleteCommand.COMMAND_WORD:
+                case ClearCommand.COMMAND_WORD:
+                case FindCommand.COMMAND_WORD:
+                case ListCommand.COMMAND_WORD:
+                case HistoryCommand.COMMAND_WORD:
+                case ExitCommand.COMMAND_WORD:
+                case HelpCommand.COMMAND_WORD:
+                case UndoCommand.COMMAND_WORD:
+                case RedoCommand.COMMAND_WORD:
+                    return command;
+                default:
+                    return Optional.empty();
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import java.util.Map;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -25,6 +26,21 @@ public interface Model {
 
     /** Adds the given person */
     void addPerson(ReadOnlyPerson person) throws DuplicatePersonException;
+
+    /**
+     * Get aliases
+     */
+    Map<String, String> getAliases();
+
+    /**
+     * Deletes the given alias.
+     */
+    void deleteAlias(String alias);
+
+    /**
+     * Adds the given alias
+     */
+    void addAlias(String alias, String command);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -25,6 +26,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     private final AddressBook addressBook;
     private final FilteredList<ReadOnlyPerson> filteredPersons;
+    private final UserPrefs userPrefs;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -36,6 +38,7 @@ public class ModelManager extends ComponentManager implements Model {
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
+        this.userPrefs = userPrefs;
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
@@ -70,6 +73,21 @@ public class ModelManager extends ComponentManager implements Model {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         indicateAddressBookChanged();
+    }
+
+    @Override
+    public synchronized Map<String, String> getAliases() {
+        return userPrefs.getAliases();
+    }
+
+    @Override
+    public synchronized void deleteAlias(String alias) {
+        userPrefs.deleteAlias(alias);
+    }
+
+    @Override
+    public synchronized void addAlias(String alias, String command) {
+        userPrefs.addAlias(alias, command);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -1,6 +1,8 @@
 package seedu.address.model;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 import seedu.address.commons.core.GuiSettings;
 
@@ -12,9 +14,11 @@ public class UserPrefs {
     private GuiSettings guiSettings;
     private String addressBookFilePath = "data/addressbook.xml";
     private String addressBookName = "MyAddressBook";
+    private Map<String, String> aliases;
 
     public UserPrefs() {
         this.setGuiSettings(500, 500, 0, 0);
+        this.aliases = new TreeMap<>();
     }
 
     public GuiSettings getGuiSettings() {
@@ -43,6 +47,18 @@ public class UserPrefs {
 
     public void setAddressBookName(String addressBookName) {
         this.addressBookName = addressBookName;
+    }
+
+    protected Map<String, String> getAliases() {
+        return aliases;
+    }
+
+    protected void addAlias(String alias, String command) {
+        this.aliases.put(alias, command);
+    }
+
+    protected void deleteAlias(String alias) {
+        this.aliases.remove(alias);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/UndoRedoStackTest.java
+++ b/src/test/java/seedu/address/logic/UndoRedoStackTest.java
@@ -236,12 +236,20 @@ public class UndoRedoStackTest {
         public CommandResult execute() {
             return new CommandResult("");
         }
+
+        public String getCommandWord() {
+            return "";
+        }
     }
 
     class DummyUndoableCommand extends UndoableCommand {
         @Override
         public CommandResult executeUndoableCommand() {
             return new CommandResult("");
+        }
+
+        public String getCommandWord() {
+            return "";
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.junit.Rule;
@@ -110,6 +111,22 @@ public class AddCommandTest {
         public ReadOnlyAddressBook getAddressBook() {
             fail("This method should not be called.");
             return null;
+        }
+
+        @Override
+        public Map<String, String> getAliases() {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public void deleteAlias(String alias) {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void addAlias(String alias, String command) {
+            fail("This method should not be called.");
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ReadOnlyPerson;
+
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteCommand}.
+ */
+public class AliasCommandTest {
+
+    private UserPrefs userPrefs;
+    private UserPrefs expectedUserPrefs;
+    private Model model;
+    private AliasCommand aliasCommand;
+
+    public static final String LIST_COMMAND_ALIAS = "show";
+
+    @Before
+    public void setUp() {
+        userPrefs = new UserPrefs();
+        expectedUserPrefs = new UserPrefs();
+
+        model = new ModelManager(getTypicalAddressBook(), userPrefs);
+
+        aliasCommand = new AliasCommand(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        aliasCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+    }
+
+    @Test
+    public void execute_alias_success() throws Exception {
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.addAlias(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
+        assertCommandSuccess(aliasCommand, model, String.format(AliasCommand.MESSAGE_SUCCESS, LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD), expectedModel);
+    }
+
+    @Test
+    public void execute_alias_commands_equal() throws Exception {
+        aliasCommand.execute();
+
+        final AddressBookParser parser = new AddressBookParser();
+        parser.setAliases(model.getAliases());
+
+        Command firstCommand = parser.parseCommand(LIST_COMMAND_ALIAS);
+        Command secondCommand = parser.parseCommand(ListCommand.COMMAND_WORD);
+        assertEquals(firstCommand.getClass(), secondCommand.getClass());
+    }
+
+    @Test
+    public void equals() {
+        AliasCommand aliasFirstCommand = new AliasCommand(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+
+        // same object -> returns true
+        assertTrue(aliasFirstCommand.equals(aliasFirstCommand));
+
+        // same values -> returns true
+        AliasCommand aliasFirstCommandCopy = new AliasCommand(LIST_COMMAND_ALIAS, ListCommand.COMMAND_WORD);
+        assertTrue(aliasFirstCommand.equals(aliasFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(aliasFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(aliasFirstCommand.equals(null));
+
+        // different alias -> returns false
+        AliasCommand aliasSecondCommand = new AliasCommand(LIST_COMMAND_ALIAS + "2", ListCommand.COMMAND_WORD);
+        assertFalse(aliasFirstCommand.equals(aliasSecondCommand));
+
+        // different command -> returns false
+        AliasCommand aliasThirdCommand = new AliasCommand(LIST_COMMAND_ALIAS, FindCommand.COMMAND_WORD);
+        assertFalse(aliasFirstCommand.equals(aliasThirdCommand));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/UndoableCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoableCommandTest.java
@@ -63,5 +63,9 @@ public class UndoableCommandTest {
             }
             return new CommandResult("");
         }
+
+        public String getCommandWord() {
+            return "";
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,25 +9,15 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.HistoryCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.RedoCommand;
-import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -46,6 +36,14 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
         assertEquals(new AddCommand(person), command);
+    }
+
+    @Test
+    public void parseCommand_alias() throws Exception {
+        parser.setAliases(new TreeMap<>());
+        AliasCommand command = (AliasCommand) parser.parseCommand(
+                AliasCommand.COMMAND_WORD + " show " + ListCommand.COMMAND_WORD);
+        assertEquals(new AliasCommand("show", ListCommand.COMMAND_WORD), command);
     }
 
     @Test


### PR DESCRIPTION
This PR adds a new `alias` command.

It is done by maintaining a map of `alias` -> `command` in the preferences, which is referred to by the AddressBookParser when determining which command to execute.

### Feedback required
- `aliases` is currently a `Map<String, String>`. Should it be abstracted into a class?
- Should we add default aliases?
- How should we implement listing/deleting aliases? I think calling `alias` without arguments should list all aliases. What about deleting?

### Notable changes
- Adds a new abstract method `getCommandWord` to each command
- Adds an `aliases` key to UserPrefs